### PR TITLE
Revoke blob URL after it is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ module.exports = function (fn) {
       new Blob([src], { type: 'text/javascript' })
     );
     var worker = new Worker(workerUrl);
-    URL.revokeObjectURL(workerUrl);
+    if (typeof URL.revokeObjectURL == "function") {
+      URL.revokeObjectURL(workerUrl);
+    }
     return worker;
 };

--- a/index.js
+++ b/index.js
@@ -49,7 +49,10 @@ module.exports = function (fn) {
     
     var URL = window.URL || window.webkitURL || window.mozURL || window.msURL;
     
-    return new Worker(URL.createObjectURL(
-        new Blob([src], { type: 'text/javascript' })
-    ));
+    var workerUrl = URL.createObjectURL(
+      new Blob([src], { type: 'text/javascript' })
+    );
+    var worker = new Worker(workerUrl);
+    URL.revokeObjectURL(workerUrl);
+    return worker;
 };


### PR DESCRIPTION
if webworkify called by many times on same page, blob URL resource is leaked.
For example, I used webworkify on electron browser process, too many blob url creation causes load error.