### PR TITLE
Fix esmodule exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ module.exports = function (fn) {
     
     for (var i = 0, l = cacheKeys.length; i < l; i++) {
         var key = cacheKeys[i];
-        if (cache[key].exports === fn) {
+        var exp = cache[key].exports;
+        if (exp === fn || exp.__esModule && exp.default === fn) {
             wkey = key;
             break;
         }
@@ -33,7 +34,11 @@ module.exports = function (fn) {
     
     var scache = {}; scache[wkey] = wkey;
     sources[skey] = [
-        Function(['require'],'require(' + stringify(wkey) + ')(self)'),
+        Function(['require'], (
+            'var mod = require(' + stringify(wkey) + ');' +
+            'var isFn = typeof mod !== "function";' +
+            '(mod.__esModule && isFn ? mod.default : mod)(self)'
+        )),
         scache
     ];
     

--- a/index.js
+++ b/index.js
@@ -8,16 +8,20 @@ module.exports = function (fn) {
     var keys = [];
     var wkey;
     var cacheKeys = Object.keys(cache);
-    
+
     for (var i = 0, l = cacheKeys.length; i < l; i++) {
         var key = cacheKeys[i];
         var exp = cache[key].exports;
-        if (exp === fn || exp.__esModule && exp.default === fn) {
+        // Using babel as a transpiler to use esmodule, the export will always
+        // be an object with the default export as a property of it. To ensure
+        // the existing api and babel esmodule exports are both supported we
+        // check for both
+        if (exp === fn || exp.default === fn) {
             wkey = key;
             break;
         }
     }
-    
+
     if (!wkey) {
         wkey = Math.floor(Math.pow(16, 8) * Math.random()).toString(16);
         var wcache = {};
@@ -31,17 +35,18 @@ module.exports = function (fn) {
         ];
     }
     var skey = Math.floor(Math.pow(16, 8) * Math.random()).toString(16);
-    
+
     var scache = {}; scache[wkey] = wkey;
     sources[skey] = [
         Function(['require'], (
-            'var mod = require(' + stringify(wkey) + ');' +
-            'var isFn = typeof mod !== "function";' +
-            '(mod.__esModule && isFn ? mod.default : mod)(self)'
+            // try to call default if defined to also support babel esmodule
+            // exports
+            'var f = require(' + stringify(wkey) + ');' +
+            '(f.default ? f.default : f)(self);'
         )),
         scache
     ];
-    
+
     var src = '(' + bundleFn + ')({'
         + Object.keys(sources).map(function (key) {
             return stringify(key) + ':['
@@ -51,9 +56,9 @@ module.exports = function (fn) {
         }).join(',')
         + '},{},[' + stringify(skey) + '])'
     ;
-    
+
     var URL = window.URL || window.webkitURL || window.mozURL || window.msURL;
-    
+
     return new Worker(URL.createObjectURL(
         new Blob([src], { type: 'text/javascript' })
     ));


### PR DESCRIPTION
When exporting a worker in ecmascript module syntax and using babel v6 as a transpiler webworkerify will throw an error "require(...)(self) is not a function".
This is because webworkerify assumes that the worker function is the export object, but in with babel v6 it will always return an object with ``default`` key as the default export function.

The fix will check whether the returning object is an esmodule or a function (because this was the case with babel v5) and will then, if it is an esmodule and not a function, call the ``default`` export instead.

This will allow to have a worker definition like the following:
``` javascript
export default function workerBody(self) {
  self.addEventListener('message', function (ev) => { ... });
}
```