### PR TITLE
Resolve deps for smaller worker blob

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,22 @@ module.exports = function (fn, options) {
         scache
     ];
 
+    var workerSources = {};
+    resolveSources(skey);
+
+    function resolveSources(key) {
+        workerSources[key] = true;
+
+        for (var depPath in sources[key][1]) {
+            var depKey = sources[key][1][depPath];
+            if (!workerSources[depKey]) {
+                resolveSources(depKey);
+            }
+        }
+    }
+
     var src = '(' + bundleFn + ')({'
-        + Object.keys(sources).map(function (key) {
+        + Object.keys(workerSources).map(function (key) {
             return stringify(key) + ':['
                 + sources[key][0]
                 + ',' + stringify(sources[key][1]) + ']'


### PR DESCRIPTION
Closes #12 by resolving all dependencies a given worker function needs, and then bundling only those for the blob instead of the whole application.

cc @anandthakker @substack @jfirebaugh