### PR TITLE
Added increased customizability to creating the webworker;

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -76,7 +76,8 @@ output.
   - name - the name of the worker thread to be assigned
   - type - the type of worker to create; `classic` or `module`; The default is `classic`
  The full list of options is [here](https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker)
- **Important note: ** if the option `bare` is used, the other options will be ignored. Pass these options in a javascript object. 
+ 
+ **Important note:** if the option `bare` is used, the other options will be ignored. Pass these options in a javascript object. 
 
 ## Worker.objectURL
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -55,7 +55,7 @@ contain output from the worker:
 var work = require('webworkify')
 ```
 
-## var w = work(require(modulePath))
+## var w = work(require(modulePath), [options])
 
 Return a new
 [web worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker)
@@ -69,6 +69,14 @@ the main thread too so don't put any computationally intensive code in that
 part. It is necessary for the main code to `require()` the worker code to fetch
 the module reference and load `modulePath`'s dependency graph into the bundle
 output.
+
+### Options
+
+  - bare - the return value will be the blob constructed with the worker's code and not the web worker itself.
+  - name - the name of the worker thread to be assigned
+  - type - the type of worker to create; `classic` or `module`; The default is `classic`
+ The full list of options is [here](https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker)
+ **Important note: ** if the option `bare` is used, the other options will be ignored. Pass these options in a javascript object. 
 
 ## Worker.objectURL
 


### PR DESCRIPTION
Added increased customizability to creating the webworker;
   Can now create webworkers with specific names, types, and credentials

Users can now create a web worker with custom names in the same `options` parameter as the `bare` option. Full list of parameters [here](https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker)

Also updated docs with edits such as [this](https://github.com/browserify/webworkify/pull/42) pull request